### PR TITLE
docs: document login endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,22 @@ Create an account with SRP6 in the `auth.account` table.
 - `409 { "error": "username already exists" }`
 - `400/500` on validation/internal errors
 
+### `POST /auth/login`
+
+Verify a user's password using SRP6 (`salt` + `verifier`).
+
+**Body**
+
+```json
+{ "username": "Foo", "password": "Bar" }
+```
+
+**Responses**
+
+- `200 { "message": "login ok" }`
+- `401 { "error": "invalid credentials" }`
+- `400/500` on validation/internal errors
+
 ---
 
 ## Security Notes


### PR DESCRIPTION
## Summary
- document POST /auth/login endpoint under Current API
- describe request body, success and failure responses, and SRP6 password verification

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a62e898d64832899a3aefefc078214