### PR TITLE
Add configurable frontend origin for CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Ports
 PORT=3001
 
+# Allowed frontend origin for CORS (e.g., http://localhost:3000)
+FRONTEND_ORIGIN=http://localhost:3000
+
 # Auth DB (Trinity/TsWoW auth)
 DB_HOST=127.0.0.1
 DB_PORT=3306

--- a/src/app.js
+++ b/src/app.js
@@ -14,8 +14,20 @@ app.use(compression());
 /** Body parsing */
 app.use(express.json({ limit: "10kb" }));
 
-/** CORS (open now; restrict later if needed) */
-app.use(cors());
+/** CORS */
+const allowedOrigin = process.env.FRONTEND_ORIGIN;
+if (allowedOrigin) {
+  app.use((req, res, next) => {
+    const origin = req.get("origin");
+    if (!origin || origin === allowedOrigin) {
+      return next();
+    }
+    return res.status(403).json({ error: "Forbidden" });
+  });
+  app.use(cors({ origin: allowedOrigin }));
+} else {
+  app.use(cors());
+}
 
 /** If behind reverse proxy / Cloudflare / IIS */
 app.set("trust proxy", 1);


### PR DESCRIPTION
## Summary
- add `FRONTEND_ORIGIN` env example to restrict API access to one frontend
- enforce allowed origin in app with 403 fallback

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a64100976c8328b8e6116aa42c4602