### PR TITLE
chore: remove obsolete helmet types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/express-rate-limit": "^5.1.3",
-        "@types/helmet": "^4.0.0",
         "@types/jsonwebtoken": "^9.0.5",
         "@types/node": "^20.11.30",
         "nodemon": "^3.1.10",
@@ -180,17 +179,6 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
-      }
-    },
-    "node_modules/@types/helmet": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/helmet/-/helmet-4.0.0.tgz",
-      "integrity": "sha512-ONIn/nSNQA57yRge3oaMQESef/6QhoeX7llWeDli0UZIfz8TQMkfNPTXA8VnnyeA1WUjG2pGqdjEIueYonMdfQ==",
-      "deprecated": "This is a stub types definition. helmet provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "helmet": "*"
       }
     },
     "node_modules/@types/http-errors": {

--- a/package.json
+++ b/package.json
@@ -35,15 +35,14 @@
     "trinitycore-srp6": "github:Krischan-Klug/trinitycore-srp6#main"
   },
   "devDependencies": {
+    "@types/compression": "^1.7.5",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/express-rate-limit": "^5.1.3",
+    "@types/jsonwebtoken": "^9.0.5",
+    "@types/node": "^20.11.30",
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.2",
-    "@types/node": "^20.11.30",
-    "@types/express": "^4.17.21",
-    "@types/cors": "^2.8.17",
-    "@types/helmet": "^4.0.0",
-    "@types/compression": "^1.7.5",
-    "@types/jsonwebtoken": "^9.0.5",
-    "@types/express-rate-limit": "^5.1.3"
+    "typescript": "^5.4.2"
   }
 }


### PR DESCRIPTION
## Summary
- remove deprecated `@types/helmet` dev dependency
